### PR TITLE
Add .intersection(r)

### DIFF
--- a/index.js
+++ b/index.js
@@ -380,10 +380,14 @@ Rectangle.prototype.intersection = function(r) {
 	if (this.x < r.x) x =    r.x, dx = this.x + this.w - r.x;
 	else              x = this.x, dx = r.x    + r.w    - this.x;
 	if (dx < 0) return null;
+	if (dx > this.w) dx = this.w;
+	if (dx > r.w)    dx = r.w;
 
 	if (this.y < r.y) y =    r.y, dy = this.y + this.h - r.y;
 	else              y = this.y, dy = r.y    + r.h    - this.y;
 	if (dy < 0) return null;
+	if (dy > this.h) dy = this.h;
+	if (dy > r.h)    dy = r.h;
 
 	return new Rectangle(x, y, dx, dy);
 }

--- a/index.js
+++ b/index.js
@@ -372,4 +372,20 @@ Rectangle.prototype.overlaps = function(x, y, w ,h) {
 				this.y < y + h && this.y + this.h > y;
 };
 
+// ## intersection(Rectangle)
+// Returns a new Rectangle representing the overlapping area of the two rectangles
+// Returns null if the two rectangles do not overlap.
+Rectangle.prototype.intersection = function(r) {
+	var x, y, dx, dy;
+	if (this.x < r.x) x =    r.x, dx = this.x + this.w - r.x;
+	else              x = this.x, dx = r.x    + r.w    - this.x;
+	if (dx < 0) return null;
+
+	if (this.y < r.y) y =    r.y, dy = this.y + this.h - r.y;
+	else              y = this.y, dy = r.y    + r.h    - this.y;
+	if (dy < 0) return null;
+
+	return new Rectangle(x, y, dx, dy);
+}
+
 module.exports = Rectangle;

--- a/test/rectangleSpec.js
+++ b/test/rectangleSpec.js
@@ -341,6 +341,7 @@ describe("Rectangle test suite:", function() {
 		it("computes the intersection", function() {
 			expect(b.intersection(b).equals(b)).toBeTruthy();
 			expect(b.intersection(new Rectangle(0,0,4,4))).toBeRectangle(1,2,3,2);
+			expect(b.intersection(new Rectangle(2,3,1,1))).toBeRectangle(2,3,1,1);
 		});
 		it("is always commutative", function() {
 			var rects = [a,b,c,d,e,f];

--- a/test/rectangleSpec.js
+++ b/test/rectangleSpec.js
@@ -334,4 +334,23 @@ describe("Rectangle test suite:", function() {
 			expect(b.overlaps(-3, -5, 1, 1)).toBeFalsy();
 		});
 	});
+	describe("intersection", function() {
+		it("returns null if the rectangles don't overlap", function() {
+			expect(b.intersection(c)).toBeNull();
+		});
+		it("computes the intersection", function() {
+			expect(b.intersection(b).equals(b)).toBeTruthy();
+			expect(b.intersection(new Rectangle(0,0,4,4))).toBeRectangle(1,2,3,2);
+		});
+		it("is always commutative", function() {
+			var rects = [a,b,c,d,e,f];
+			for (var i=0; i<rects.length; i++) {
+				for (var j=0; j<rects.length; j++) {
+					var d1 = rects[i].intersection(rects[j]);
+					var d2 = rects[j].intersection(rects[i]);
+					expect(d1 === null ? d1 === d2 : d1.equals(d2)).toBeTruthy();
+				}
+			}
+		});
+	});
 });


### PR DESCRIPTION
Add Rectangle.prototype.intersection(Rectangle) that computes the
intersection of two rectangles.

The method returns null if the two rectangles don't intersect. Maybe it should return a new Rectangle(0,0,0,0) in this case to make chaining methods easier. 
